### PR TITLE
refactor public_access s3

### DIFF
--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -79,8 +79,8 @@ resource "aws_s3_bucket_public_access" "this" {
 
   bucket = aws_s3_bucket.this.id
 
-  block_public_acls       = var.block_public_access
-  block_public_policy     = var.block_public_policy
-  restrict_public_buckets = var.restrict_public_buckets
-  ignore_public_acls      = var.ignore_public_acls
+  block_public_acls       = try(var.block_public_access, true)
+  block_public_policy     = try(var.block_public_policy, true)
+  restrict_public_buckets = try(var.restrict_public_buckets, true)
+  ignore_public_acls      = try(var.ignore_public_acls, true)
 }

--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -75,13 +75,12 @@ resource "aws_s3_bucket_policy" "this" {
   )
 }
 
-resource "aws_s3_bucket_public_access_block" "this" {
-  count = var.block_public_access ? 1 : 0
+resource "aws_s3_bucket_public_access" "this" {
 
   bucket = aws_s3_bucket.this.id
 
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  block_public_acls       = var.block_public_access
+  block_public_policy     = var.block_public_policy
+  restrict_public_buckets = var.restrict_public_buckets
+  ignore_public_acls      = var.ignore_public_acls
 }

--- a/aws/s3/variables.tf
+++ b/aws/s3/variables.tf
@@ -18,6 +18,26 @@ variable "block_public_access" {
   default = true
 }
 
+variable "block_public_acls" {
+  type   =  bool
+  default = true
+}
+
+variable "block_public_policy" {
+  type   =  bool
+  default = true
+}
+
+variable "restrict_public_buckets" {
+  type   =  bool
+  default = true
+}
+
+variable "ignore_public_acls" {
+  type   =  bool
+  default = true
+}
+
 variable "bucket_policy" {
   type    = any
   default = null


### PR DESCRIPTION
By default wasn't allow policies. 
Because when the bucket is creating with aws_s3_bucket_acl is setting by default 
``` 
 block_public_acls       = true
  block_public_policy     = true
  restrict_public_buckets = true
  ignore_public_acls      = true
```