### PR TITLE
fix: deprecate vpc variable in eip

### DIFF
--- a/aws/network/main.tf
+++ b/aws/network/main.tf
@@ -51,8 +51,8 @@ resource "aws_subnet" "private" {
 
 /* Gateways Nat and Internet */
 resource "aws_eip" "nat" {
-  count = length(var.az_zones)
-  vpc   = true
+  count  = length(var.az_zones)
+  domain = "vpc"
   tags = {
     Name        = "${var.name}-${var.az_zones[count.index]}-eip"
     Description = "Internet Gateway for NAT Gateway"
@@ -94,7 +94,7 @@ resource "aws_route_table" "private" {
 
   dynamic "route" {
     for_each = concat(
-      var.extra_private_routes, 
+      var.extra_private_routes,
       try(var.extra_private_routes_per_az[var.az_zones[count.index]], [])
     )
 


### PR DESCRIPTION
│ Warning: Argument is deprecated
│ 
│   with module.vpc.module.vpc_network.aws_eip.nat[1],
│   on .terraform/modules/vpc.vpc_network/aws/network/main.tf line 55, in resource "aws_eip" "nat":
│   55:   vpc   = true
│ 
│ use domain attribute instead

This PR fixes the warning on aws_eip resource.

Tested locally.