### PR TITLE
fix: rds: include enhanced monitoring role

### DIFF
--- a/aws/rds/enhanced_monitoring.tf
+++ b/aws/rds/enhanced_monitoring.tf
@@ -19,7 +19,13 @@ data "aws_iam_policy_document" "enhanced_monitoring" {
 
     principals {
       type        = "Service"
-      identifiers = ["rds.amazonaws.com"]
+      identifiers = ["monitoring.rds.amazonaws.com"]
     }
   }
+}
+
+resource "aws_iam_role_policy_attachment" "enhanced_monitoring-attach" {
+  count      = var.create_monitoring_role ? 1 : 0
+  role       = aws_iam_role.enhanced_monitoring[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }

--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -5,3 +5,7 @@ output "this" {
 output "sg" {
   value = aws_security_group.this
 }
+
+output "enhanced_monitoring_role_arn" {
+  value = aws_iam_role.enhanced_monitoring[0].arn
+}


### PR DESCRIPTION
│ Error: creating RDS DB Instance (dev-db): InvalidParameterValue: IAM role ARN value is invalid or does not include the required permissions for: ENHANCED_MONITORING
│       status code: 400, request id: 2fa987f0-588d-4dc1-8a3f-600467e013b4

This PR fixes the error on rds module when creating enhanced monitoring role.