### PR TITLE
added tags for redis elasticache_replication_group

### DIFF
--- a/aws/redis/main.tf
+++ b/aws/redis/main.tf
@@ -41,6 +41,7 @@ resource "aws_elasticache_replication_group" "redis" {
   engine_version             = var.engine_version
   engine                     = "redis"
   multi_az_enabled           = var.multi_az_enabled
+  tags                       = var.tags
 
   parameter_group_name = (
     var.parameter_group_name == null

--- a/aws/redis/variables.tf
+++ b/aws/redis/variables.tf
@@ -18,6 +18,11 @@ variable "platform" {
   description = "Name of Platform or Brand"
 }
 
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
 variable "port" {
   type        = number
   description = "port number for redis"


### PR DESCRIPTION
I encountered some drift in terraform with the tags for redis, further investigating I found the tag field is missing in the modules for redis.
I have added the tags to redis module.