### PR TITLE
feat: Add tags variable to redis

### DIFF
--- a/aws/redis/main.tf
+++ b/aws/redis/main.tf
@@ -41,6 +41,7 @@ resource "aws_elasticache_replication_group" "redis" {
   engine_version             = var.engine_version
   engine                     = "redis"
   multi_az_enabled           = var.multi_az_enabled
+  tags                       = var.tags
 
   parameter_group_name = (
     var.parameter_group_name == null

--- a/aws/redis/variables.tf
+++ b/aws/redis/variables.tf
@@ -36,6 +36,11 @@ variable "size" {
   default = "t2.small"
 }
 
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
 variable "security_group_id" {
   type        = string
   description = "The id of the general security group"


### PR DESCRIPTION
I encountered some drift in terraform with the tags for redis, further investigating I found the tag field is missing in the modules for redis.
I have added the tags to redis module.