### PR TITLE
feat: add maximum allocated storage to rds modules

### DIFF
--- a/aws/rds/examples/default/main.tf
+++ b/aws/rds/examples/default/main.tf
@@ -27,6 +27,7 @@ module "db" {
   username                    = "testdbuser"
   password                    = "testdbpassword"
   allocated_storage           = 10
+  max_allocated_storage       = 100
   manage_master_user_password = null
   final_snapshot_identifier   = "test-db-instance-final-snapshot"
   deletion_protection         = false

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -46,7 +46,7 @@ resource "aws_db_instance" "this" {
   monitoring_interval = var.monitoring_interval
   monitoring_role_arn = local.monitoring_role_arn
 
-  max_allocated_storage = var.max_allocated_storage_factor * var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage
 
   vpc_security_group_ids = [
     aws_security_group.this.id

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -139,3 +139,8 @@ variable "max_allocated_storage_factor" {
   default = 2 # by deafult twice the amount of disk for the db instance
   nullable = false
 }
+
+variable "max_allocated_storage" {
+  type    = number
+  nullable = false
+}

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -134,12 +134,6 @@ variable "create_monitoring_role" {
   default = false
 }
 
-variable "max_allocated_storage_factor" {
-  type    = number
-  default = 2 # by deafult twice the amount of disk for the db instance
-  nullable = false
-}
-
 variable "max_allocated_storage" {
   type    = number
   nullable = false


### PR DESCRIPTION
Previously RDS maximum allocated storage was calculated using **var.max_allocated_storage_factor * var.allocated_storage** but it would give more flexibility if we define the max_allocated_storage variable instead of this equation and for some RDS we are having different max_storage which sometime gives drift in terraform if we manually update the RDS from aws.

I also modified the sample file with the new var : max_allocated_storage