### PR TITLE
feat: Add message to create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,4 @@ jobs:
           git push origin v${{ steps.release.outputs.major }}
           git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}
 
+


### PR DESCRIPTION
The previous PR approved https://github.com/TradrAPI/terraform-modules/pull/19
Wasn't create a version. It is related with the PR title and commit messages.
The previous commit message didn't contain feat word. And the PR title started with feat(): instead feat:

After approve the current PR it will create a new version and will tag the repo with this version.

Pipeline related https://github.com/TradrAPI/terraform-modules/actions/runs/8186267572/job/22384329370#step:2:489