### PR TITLE
feat: add inputs on aws kms module

### DIFF
--- a/aws/kms/common_locals.tf
+++ b/aws/kms/common_locals.tf
@@ -4,8 +4,8 @@ locals {
   }
 
   names = {
-    fqn        = var.name
-    kms_user   = "${var.name}-kms"
-    kms_policy = replace(title("${var.name} kms"), "/\\s|-/", "")
+    fqn        = "${var.prefix}${var.platform}-${var.name}"
+    kms_user   = "${var.prefix}${var.platform}-${var.name}-kms"
+    kms_policy = replace(title("${var.prefix}${var.platform} ${var.name} kms"), "/\\s|-/", "")
   }
 }

--- a/aws/kms/variables.tf
+++ b/aws/kms/variables.tf
@@ -1,5 +1,14 @@
+variable "platform" {
+  type = string
+}
+
 variable "name" {
   type = string
+}
+
+variable "prefix" {
+  type    = string
+  default = ""
 }
 
 variable "create_user" {


### PR DESCRIPTION
I add two inputs on the kms modules.

- Platform we can use this variable for reference k8s clusters
- Prefix we can use this variable for reference environment id like stg,dev,prd

