### PR TITLE
fix: Uses null defaults for iops and storage_throughput

### DIFF
--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -141,12 +141,12 @@ variable "max_allocated_storage" {
 
 variable "iops" {
   type    = number
-  default = 3000
+  default = null
 }
 
 variable "storage_throughput" {
   type    = number
-  default = 125
+  default = null
 }
 
 variable "storage_encrypted" {


### PR DESCRIPTION
This prevents errors from module's clients upgrading to newer versions