### PR TITLE
fix: add required_provider on secret module

### DIFF
--- a/aws/secrets/main.tf
+++ b/aws/secrets/main.tf
@@ -1,6 +1,13 @@
 terraform {
   required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }
+
 
 resource "aws_secretsmanager_secret" "secret" {
   name                    = "${var.name}"


### PR DESCRIPTION
Root case 
We are getting  this warning when we instance the module.
```
╷
│ Warning: Reference to undefined provider
│ 
│   on secrets.tf line 5, in module "secrets":
│    5:     aws = aws.secrets
│ 
│ There is no explicit declaration for local provider name "aws" in
│ module.secrets, so Terraform is assuming you mean to pass a configuration
│ for "hashicorp/aws".
│ 
│ If you also control the child module, add a required_providers entry named
│ "aws" with the source address "hashicorp/aws".
```

This code fix this warning.
