### PR TITLE
fix: Allows customizing ec2 group description

### DIFF
--- a/aws/ec2/sg.tf
+++ b/aws/ec2/sg.tf
@@ -1,7 +1,8 @@
 
 resource "aws_security_group" "this" {
-  name        = "${var.resources_prefix}-ec2-sg"
-  description = var.sg_description
+  name = "${var.resources_prefix}-ec2-sg"
+
+  description = coalesce(var.sg_description, "${var.name} security group")
 
   vpc_id = var.vpc_id
 }

--- a/aws/ec2/sg.tf
+++ b/aws/ec2/sg.tf
@@ -1,7 +1,7 @@
 
 resource "aws_security_group" "this" {
   name        = "${var.resources_prefix}-ec2-sg"
-  description = "${var.name} security group"
+  description = var.sg_description
 
   vpc_id = var.vpc_id
 }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -167,5 +167,5 @@ variable "iam_instance_profile" {
 
 variable "sg_description" {
   type    = string
-  default = "${var.name} security group"
+  default = ""
 }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -164,3 +164,8 @@ variable "iam_instance_profile" {
   default  = null
   nullable = true
 }
+
+variable "sg_description" {
+  type    = string
+  default = "${var.name} security group"
+}


### PR DESCRIPTION
Non breaking change to avoid recreating SGs when the instance name changes