### PR TITLE
fix(network): Add unique values on concat lists to aboid errors

### DIFF
--- a/aws/network/main.tf
+++ b/aws/network/main.tf
@@ -156,11 +156,11 @@ resource "aws_route_table" "private" {
   }
 
   dynamic "route" {
-    for_each = concat(
+    for_each = distinct(concat(
       var.extra_private_routes,
       local.extra_tgw_routes,
       try(var.extra_private_routes_per_az[var.az_zones[count.index]], []),
-    )
+    ))
 
     content {
       cidr_block                = route.value["cidr_block"]
@@ -191,10 +191,10 @@ resource "aws_route_table" "public" {
   }
 
   dynamic "route" {
-    for_each = concat(
+    for_each = distinct(concat(
       var.extra_public_routes,
       var.enable_tgw_routes_in_public_subnets ? local.extra_tgw_routes : [],
-    )
+    ))
 
     content {
       cidr_block                = route.value["cidr_block"]

--- a/aws/network/outputs.tf
+++ b/aws/network/outputs.tf
@@ -20,7 +20,7 @@ output "private_route_tables_v2" {
 
 output "private_routes_v2" {
   value = concat(
-    aws_route.private_nat_v2, 
+    aws_route.private_nat_v2,
     values(aws_route.private_v2),
   )
 }

--- a/aws/network/route_table_v2.tf
+++ b/aws/network/route_table_v2.tf
@@ -66,14 +66,14 @@ resource "aws_route" "public_v2" {
 
 locals {
   private_routes_v2 = merge({
-    for index, az_route in setproduct(var.az_zones, concat(var.extra_private_routes, local.extra_tgw_routes)) :
+    for index, az_route in setproduct(var.az_zones, distinct(concat(var.extra_private_routes, local.extra_tgw_routes))) :
     "${az_route[0]}/${az_route[1].cidr_block}" => merge(az_route[1], { az = az_route[0] })
   })
 
-  _extra_public_routes = concat(
-    var.extra_public_routes, 
+  _extra_public_routes = distinct(concat(
+    var.extra_public_routes,
     var.enable_tgw_routes_in_public_subnets ? local.extra_tgw_routes : []
-  )
+  ))
 
   public_routes_v2 = {
     for index, az_route in setproduct(var.az_zones, local._extra_public_routes) :


### PR DESCRIPTION
Fix the error when  set intersection (extra_privates_routes, extra_tgw_routes) is not empty.

Error: Duplicate object key
on .terraform/modules/network/aws/network/route_table_v2.tf line 70, in locals:
  private_routes_v2 = merge({
    for index, az_route in setproduct(var.az_zones, concat(var.extra_private_routes, local.extra_tgw_routes)) :
    "${az_route[0]}/${az_route[1].cidr_block}" => merge(az_route[1], { az = az_route[0] })
  })
az_route[0] is "<value-zone>"
az_route[1].cidr_block is "<value-cidr>"
Two different items produced the key "<value-zone>/<value-cidr> in this 'for' expression. If duplicates are expected, use the ellipsis (...) after the value expression to enable grouping by key.