### PR TITLE
fix(mongodb): Resolve undetermined count issue in random_password

### DIFF
--- a/mongodbatlas/user/main.tf
+++ b/mongodbatlas/user/main.tf
@@ -8,7 +8,7 @@ data "mongodbatlas_cluster" "this" {
 resource "mongodbatlas_database_user" "user" {
   provider           = mongodbatlas.creds 
   username           = var.external_username != null ? var.external_username : lower("${var.platform}-${var.brandname}${var.name_suffix}")
-  password           = var.external_password != null ? var.external_password : random_password.password[0].result
+  password           = try(var.external_password, random_password.password[0].result)
   project_id         = var.mongodb_projectid
   auth_database_name = "admin"
 
@@ -32,7 +32,7 @@ resource "mongodbatlas_database_user" "user" {
 }
 
 resource "random_password" "password" {
-  count   = var.external_password != null ? 0 : 1 # Use the password based on the condition
+  count   = var.external_password != null ? 0 : 1
   length  = 24
   special = false
 }

--- a/mongodbatlas/user/main.tf
+++ b/mongodbatlas/user/main.tf
@@ -8,7 +8,7 @@ data "mongodbatlas_cluster" "this" {
 resource "mongodbatlas_database_user" "user" {
   provider           = mongodbatlas.creds 
   username           = var.external_username != null ? var.external_username : lower("${var.platform}-${var.brandname}${var.name_suffix}")
-  password           = try(var.external_password, random_password.password[0].result)
+  password           = try(var.external_password, random_password.password.result)
   project_id         = var.mongodb_projectid
   auth_database_name = "admin"
 
@@ -32,7 +32,7 @@ resource "mongodbatlas_database_user" "user" {
 }
 
 resource "random_password" "password" {
-  count   = var.external_password != null ? 0 : 1
+
   length  = 24
   special = false
 }


### PR DESCRIPTION
**Overview**

![image](https://github.com/user-attachments/assets/2bea79e5-e89a-4b4f-bcb1-a3776c8c8eac)

In this update, I've encapsulated the password block within the `try()` function. This enhancement allows us to seamlessly manage the MongoDB user password:

**Custom Password:** If a password is provided (external_password), the system will use it directly.
**Auto-Generated Password:** If no password is provided, the default random_password generator will automatically create a secure password.
