### PR TITLE
fix: Random password module

### DIFF
--- a/mongodbatlas/user/main.tf
+++ b/mongodbatlas/user/main.tf
@@ -35,6 +35,9 @@ resource "random_password" "password" {
 
   length  = 24
   special = false
+  lifecycle {
+    ignore_changes = [length, special]
+  }
 }
 
 locals {


### PR DESCRIPTION
**Overview**

Importing the resource using terraform import random_password.password securepassword, would result in the triggering of a replacement (i.e., destroy-create) during the next terraform apply
Replacement could be avoided by using **_ignore_changes_** specifying the attributes to ignore