### PR TITLE
fix(ec2): Setting iops variable to default null

### DIFF
--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -124,7 +124,7 @@ variable "root_volume_type" {
 
 variable "iops" {
   type    = number
-  default = 3000
+  default = null
 }
 
 variable "security_group_ids" {


### PR DESCRIPTION
Setting iops variable in EC2 as default null for more flexibility and reusability. 