### PR TITLE
feat(kafka): Add amazon-s3-sing-connector-url

### DIFF
--- a/aws/kafka/README.md
+++ b/aws/kafka/README.md
@@ -62,7 +62,7 @@ No requirements.
 | <a name="input_number_of_broker_nodes"></a> [number\_of\_broker\_nodes](#input\_number\_of\_broker\_nodes) | Number of broker nodes. | `number` | `3` | no |
 | <a name="input_platform"></a> [platform](#input\_platform) | Platform name. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `null` | no |
-| <a name="input_server_properties"></a> [server\_properties](#input\_server\_properties) | Server properties. | `string` | `{}` | no |
+| <a name="input_server_properties"></a> [server\_properties](#input\_server\_properties) | Server properties. | `string` | `null` | no |
 | <a name="input_users"></a> [users](#input\_users) | MSK users. | `list(string)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id. where the MSK cluster will be created. | `string` | `null` | no |
 

--- a/aws/kafka/README.md
+++ b/aws/kafka/README.md
@@ -61,6 +61,7 @@ No requirements.
 | <a name="input_msk_instance_type"></a> [msk\_instance\_type](#input\_msk\_instance\_type) | MSK instance type. | `string` | `"kafka.t3.small"` | no |
 | <a name="input_number_of_broker_nodes"></a> [number\_of\_broker\_nodes](#input\_number\_of\_broker\_nodes) | Number of broker nodes. | `number` | `3` | no |
 | <a name="input_platform"></a> [platform](#input\_platform) | Platform name. | `string` | `null` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Private subnets. | `list(string)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `null` | no |
 | <a name="input_server_properties"></a> [server\_properties](#input\_server\_properties) | Server properties. | `string` | `null` | no |
 | <a name="input_users"></a> [users](#input\_users) | MSK users. | `list(string)` | `[]` | no |

--- a/aws/kafka/README.md
+++ b/aws/kafka/README.md
@@ -62,6 +62,7 @@ No requirements.
 | <a name="input_number_of_broker_nodes"></a> [number\_of\_broker\_nodes](#input\_number\_of\_broker\_nodes) | Number of broker nodes. | `number` | `3` | no |
 | <a name="input_platform"></a> [platform](#input\_platform) | Platform name. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `null` | no |
+| <a name="input_server_properties"></a> [server\_properties](#input\_server\_properties) | Server properties. | `map(string)` | `{}` | no |
 | <a name="input_users"></a> [users](#input\_users) | MSK users. | `list(string)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id. where the MSK cluster will be created. | `string` | `null` | no |
 

--- a/aws/kafka/README.md
+++ b/aws/kafka/README.md
@@ -60,7 +60,6 @@ No requirements.
 | <a name="input_msk_instance_type"></a> [msk\_instance\_type](#input\_msk\_instance\_type) | MSK instance type. | `string` | `"kafka.t3.small"` | no |
 | <a name="input_number_of_broker_nodes"></a> [number\_of\_broker\_nodes](#input\_number\_of\_broker\_nodes) | Number of broker nodes. | `number` | `3` | no |
 | <a name="input_platform"></a> [platform](#input\_platform) | Platform name. | `string` | `null` | no |
-| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Private subnets. | `list(string)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `null` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | Security groups. | `list(string)` | `[]` | no |
 | <a name="input_users"></a> [users](#input\_users) | MSK users. | `list(string)` | `[]` | no |

--- a/aws/kafka/README.md
+++ b/aws/kafka/README.md
@@ -52,6 +52,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | Allowed CIDR blocks. | `list(string)` | `[]` | no |
+| <a name="input_amazon-s3-sink-connector-url"></a> [amazon-s3-sink-connector-url](#input\_amazon-s3-sink-connector-url) | Amazon S3 Sink Connector URL | `string` | `"https://d2p6pa21dvn84.cloudfront.net/api/plugins/confluentinc/kafka-connect-s3/versions/10.5.2/confluentinc-kafka-connect-s3-10.5.2.zip"` | no |
 | <a name="input_client_subnets"></a> [client\_subnets](#input\_client\_subnets) | Client subnets. | `list(string)` | `[]` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | msk cluster name. | `string` | `null` | no |
 | <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | EBS volume size. | `number` | `10` | no |
@@ -61,7 +62,6 @@ No requirements.
 | <a name="input_number_of_broker_nodes"></a> [number\_of\_broker\_nodes](#input\_number\_of\_broker\_nodes) | Number of broker nodes. | `number` | `3` | no |
 | <a name="input_platform"></a> [platform](#input\_platform) | Platform name. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `null` | no |
-| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | Security groups. | `list(string)` | `[]` | no |
 | <a name="input_users"></a> [users](#input\_users) | MSK users. | `list(string)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id. where the MSK cluster will be created. | `string` | `null` | no |
 

--- a/aws/kafka/README.md
+++ b/aws/kafka/README.md
@@ -62,7 +62,7 @@ No requirements.
 | <a name="input_number_of_broker_nodes"></a> [number\_of\_broker\_nodes](#input\_number\_of\_broker\_nodes) | Number of broker nodes. | `number` | `3` | no |
 | <a name="input_platform"></a> [platform](#input\_platform) | Platform name. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | `null` | no |
-| <a name="input_server_properties"></a> [server\_properties](#input\_server\_properties) | Server properties. | `map(string)` | `{}` | no |
+| <a name="input_server_properties"></a> [server\_properties](#input\_server\_properties) | Server properties. | `string` | `{}` | no |
 | <a name="input_users"></a> [users](#input\_users) | MSK users. | `list(string)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id. where the MSK cluster will be created. | `string` | `null` | no |
 

--- a/aws/kafka/main.tf
+++ b/aws/kafka/main.tf
@@ -5,12 +5,12 @@ locals {
   ))
 
   _server_properties_good_defaults = [
-    "num.partitions=${3 * local.var.msk.number_of_broker_nodes}",
+    "num.partitions=${3 * var.msk.number_of_broker_nodes}",
     "log.retention.hours=168",
   ]
 
   _server_properties_without_locally_provided = [
-    for property in split("\n", local.var.msk.server_properties) :
+    for property in split("\n", var.msk.server_properties) :
     property
     if(
       property != ""

--- a/aws/kafka/main.tf
+++ b/aws/kafka/main.tf
@@ -5,12 +5,12 @@ locals {
   ))
 
   _server_properties_good_defaults = [
-    "num.partitions=${3 * var.msk.number_of_broker_nodes}",
+    "num.partitions=${3 * var.number_of_broker_nodes}",
     "log.retention.hours=168",
   ]
 
   _server_properties_without_locally_provided = [
-    for property in split("\n", var.msk.server_properties) :
+    for property in split("\n", var.server_properties) :
     property
     if(
       property != ""
@@ -24,7 +24,7 @@ locals {
 
 
 resource "aws_msk_configuration" "this" {
-  kafka_versions = [var.msk.kafka_version]
+  kafka_versions = [var.kafka_version]
 
   name = "${var.platform}-${var.environment}-${replace(var.kafka_version, ".", "")}"
 

--- a/aws/kafka/main.tf
+++ b/aws/kafka/main.tf
@@ -66,7 +66,7 @@ resource "aws_msk_cluster" "this" {
       }
     }
 
-    security_groups = var.security_groups
+    security_groups = [aws_security_group.msk.id]
   }
 
   client_authentication {
@@ -105,7 +105,7 @@ resource "aws_msk_cluster" "this" {
 }
 
 resource "aws_security_group" "msk" {
-  name        = "${var.platform}-${var.cluster_name}-${var.environment}-msk"
+  name        = var.cluster_name
   description = "MSK security group"
   vpc_id      = var.vpc_id
 

--- a/aws/kafka/plugins.tf
+++ b/aws/kafka/plugins.tf
@@ -2,7 +2,7 @@ locals {
   plugins = {
     # Write data from kafka to s3 backup
     "amazon-s3-sink-connector" = {
-      url = "https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-s3/versions/10.5.5/confluentinc-kafka-connect-s3-10.5.5.zip"
+      url = "${var.amazon-s3-sink-connector}"
     }
     # Write data from s3 to kafka restore
     "amazon-s3-source-connector" = {

--- a/aws/kafka/plugins.tf
+++ b/aws/kafka/plugins.tf
@@ -2,7 +2,7 @@ locals {
   plugins = {
     # Write data from kafka to s3 backup
     "amazon-s3-sink-connector" = {
-      url = "${var.amazon-s3-sink-connector}"
+      url = "${var.amazon-s3-sink-connector-url}"
     }
     # Write data from s3 to kafka restore
     "amazon-s3-source-connector" = {

--- a/aws/kafka/variable.tf
+++ b/aws/kafka/variable.tf
@@ -94,6 +94,6 @@ variable "region" {
 variable "server_properties" {
   description = "Server properties."
   type        = string
-  default     = {}
+  default     = null
 
 }

--- a/aws/kafka/variable.tf
+++ b/aws/kafka/variable.tf
@@ -97,3 +97,10 @@ variable "server_properties" {
   default     = null
 
 }
+
+
+variable "private_subnets" {
+  description = "Private subnets."
+  type        = list(string)
+  default     = []
+}

--- a/aws/kafka/variable.tf
+++ b/aws/kafka/variable.tf
@@ -64,11 +64,7 @@ variable "vpc_id" {
   default     = null
 }
 
-variable "security_groups" {
-  description = "Security groups."
-  type        = list(string)
-  default     = []
-}
+
 
 
 variable "allowed_cidr_blocks" {

--- a/aws/kafka/variable.tf
+++ b/aws/kafka/variable.tf
@@ -1,4 +1,9 @@
 
+variable "amazon-s3-sink-connector-url" {
+  description = "Amazon S3 Sink Connector URL"
+  type        = string
+  default     = "https://d2p6pa21dvn84.cloudfront.net/api/plugins/confluentinc/kafka-connect-s3/versions/10.5.2/confluentinc-kafka-connect-s3-10.5.2.zip"
+}
 variable "platform" {
   description = "Platform name."
   type        = string
@@ -89,8 +94,3 @@ variable "region" {
   default     = null
 }
 
-variable "private_subnets" {
-  description = "Private subnets."
-  type        = list(string)
-  default     = []
-}

--- a/aws/kafka/variable.tf
+++ b/aws/kafka/variable.tf
@@ -90,3 +90,10 @@ variable "region" {
   default     = null
 }
 
+
+variable "server_properties" {
+  description = "Server properties."
+  type        = map(string)
+  default     = {}
+
+}

--- a/aws/kafka/variable.tf
+++ b/aws/kafka/variable.tf
@@ -93,7 +93,7 @@ variable "region" {
 
 variable "server_properties" {
   description = "Server properties."
-  type        = map(string)
+  type        = string
   default     = {}
 
 }


### PR DESCRIPTION
This pull request includes several changes to the AWS Kafka module, focusing on updating configurations and removing unused variables. The most important changes include updating the URL for the Amazon S3 Sink Connector, removing the `private_subnets` variable, and adding a new variable for the Amazon S3 Sink Connector URL because this url is not static.

Configuration Updates:

* [`aws/kafka/plugins.tf`](diffhunk://#diff-482edd130c58d1b5b5d5735acc49dc4e8a86dcafb3cba66244eb66f771cdd71fL5-R5): Updated the URL for the Amazon S3 Sink Connector to use a variable instead of a hardcoded string.
* [`aws/kafka/variable.tf`](diffhunk://#diff-3639950b570e4ed71b04b4f89661a858e60a7e70dacf8220dcec50c22986adf6R2-R6): Added a new variable `amazon-s3-sink-connector-url` for the Amazon S3 Sink Connector URL.

Removal of Unused Variables:

* [`aws/kafka/README.md`](diffhunk://#diff-b4b921f19b38c4cb903c871750aa1afabd31ddedfe7012f1b76607d3aae664e3L63): Removed the `private_subnets` input from the documentation.
* [`aws/kafka/variable.tf`](diffhunk://#diff-3639950b570e4ed71b04b4f89661a858e60a7e70dacf8220dcec50c22986adf6L92-L96): Removed the `private_subnets` variable definition.