### PR TITLE
feat(kafka): Deletes backed up messages after 14days

### DIFF
--- a/aws/kafka/main.tf
+++ b/aws/kafka/main.tf
@@ -109,6 +109,11 @@ resource "aws_security_group" "msk" {
   description = "MSK security group"
   vpc_id      = var.vpc_id
 
+  lifecycle {
+    ignore_changes = [
+      description
+    ]
+  }
 }
 
 


### PR DESCRIPTION
We store topic messages in kafka for 7days. 
I believe we don't need to keep them in the backup bucket forever.
This PR updates it so we keep them for 14days only.