### PR TITLE
feat(turbo_repo_remote_cache): Add conditional rule to create lambda function

### DIFF
--- a/apps/turbo_repo_remote_cache/README.md
+++ b/apps/turbo_repo_remote_cache/README.md
@@ -26,6 +26,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_lambda"></a> [create\_lambda](#input\_create\_lambda) | n/a | `bool` | `true` | no |
 | <a name="input_extra_environment_variables"></a> [extra\_environment\_variables](#input\_extra\_environment\_variables) | n/a | `map(string)` | `{}` | no |
 | <a name="input_layers"></a> [layers](#input\_layers) | n/a | `list(string)` | `[]` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | n/a | `number` | `128` | no |

--- a/apps/turbo_repo_remote_cache/main.tf
+++ b/apps/turbo_repo_remote_cache/main.tf
@@ -1,4 +1,5 @@
 module "lambda" {
+  count   = var.create_lambda ? 1 : 0
   source  = "terraform-aws-modules/lambda/aws"
   version = "7.2.5"
 

--- a/apps/turbo_repo_remote_cache/outputs.tf
+++ b/apps/turbo_repo_remote_cache/outputs.tf
@@ -1,5 +1,5 @@
 output "lambda_function_url" {
-  value = module.lambda.lambda_function_url
+  value = var.create_lambda ? module.lambda[0].lambda_function_url : null
 }
 
 output "turbo_token" {

--- a/apps/turbo_repo_remote_cache/variables.tf
+++ b/apps/turbo_repo_remote_cache/variables.tf
@@ -28,3 +28,9 @@ variable "layers" {
   type    = list(string)
   default = []
 }
+
+
+variable "create_lambda" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
This pull request introduces a new variable, `create_lambda`, to conditionally control the creation of the Lambda module in the `apps/turbo_repo_remote_cache` Terraform configuration. This change enhances flexibility by allowing users to enable or disable the Lambda resource as needed. The most important changes are grouped below:

### New Variable Addition:
* Added a new variable, `create_lambda`, of type `bool` with a default value of `true` in `apps/turbo_repo_remote_cache/variables.tf`. This variable determines whether the Lambda resource should be created.

### Conditional Logic for Lambda Creation:
* Updated the `lambda` module in `apps/turbo_repo_remote_cache/main.tf` to use the `count` argument, which is set based on the value of `create_lambda`. If `create_lambda` is `false`, the Lambda resource is not created.
* Modified the `lambda_function_url` output in `apps/turbo_repo_remote_cache/outputs.tf` to return `null` if `create_lambda` is `false`. This ensures compatibility when the Lambda resource is not created.

### Documentation Update:
* Added documentation for the `create_lambda` variable in `apps/turbo_repo_remote_cache/README.md` to describe its purpose and default value.